### PR TITLE
Option "errors" must be boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (ajv, options) {
     inline: require('./lib/dotjs/errorMessage'),
     statements: true,
     valid: true,
-    errors: 'full',
+    errors: true,
     config: {
       KEYWORD_PROPERTY_PARAMS: {
         required: 'missingProperty',


### PR DESCRIPTION
Fixing problem of "custom keyword definition is invalid: data.errors should be boolean".
Ex. issue in webpack:
[https://github.com/webpack/webpack/issues/8768](url)
